### PR TITLE
Added retry and delay logic for sending DSD emails in a loop.

### DIFF
--- a/book-a-reading-room-visit.api/Controllers/BookingController.cs
+++ b/book-a-reading-room-visit.api/Controllers/BookingController.cs
@@ -2,6 +2,7 @@
 using book_a_reading_room_visit.domain;
 using book_a_reading_room_visit.model;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
@@ -13,10 +14,12 @@ namespace book_a_reading_room_visit.api.Controllers
     public class BookingController : ControllerBase
     {
         private readonly IBookingService _bookingService;
+        private readonly ILogger _logger;
 
-        public BookingController(IBookingService bookingService)
+        public BookingController(IBookingService bookingService, ILogger<BookingController> logger)
         {
             _bookingService = bookingService;
+            _logger = logger;
         }
 
         [HttpPost("create")]
@@ -189,7 +192,9 @@ namespace book_a_reading_room_visit.api.Controllers
         [HttpPost("send-confirmation")]
         public async Task<ActionResult<int>> SendBookingConfirmationEmails(DateTime completeBy)
         {
+            _logger.LogInformation($"Starting sending confirmation emails for bookings with complete by date {completeBy}.");
             int result = await _bookingService.SendBookingConfirmationEmailsAsync(completeBy);
+            _logger.LogInformation($"Finished sending confirmation emails for bookings with complete by date {completeBy}. {result} bookings were processed.");
             return Ok(result);
         }
 

--- a/book-a-reading-room-visit.api/Documentation/NLog_Slack_Integeration.txt
+++ b/book-a-reading-room-visit.api/Documentation/NLog_Slack_Integeration.txt
@@ -1,0 +1,6 @@
+﻿Nlog is used by the KBS API and can be  configured to post to Slack.
+This requirs the use of a webhook which in turn is owned by an app you create within the Slack workspace
+In the tna-digital Slack workspace:
+- the app is Kew Booking System App
+- the webhook within this app is https://hooks.slack.com/services/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
+- the webhook is configured to post to the ds-kbs-notifications channel

--- a/book-a-reading-room-visit.api/Program.cs
+++ b/book-a-reading-room-visit.api/Program.cs
@@ -1,11 +1,7 @@
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using NLog.Web;
 
 namespace book_a_reading_room_visit.api
 {
@@ -13,7 +9,21 @@ namespace book_a_reading_room_visit.api
     {
         public static void Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
+            var logger = NLog.Web.NLogBuilder.ConfigureNLog("nLog.config").GetCurrentClassLogger();
+            try
+            {
+                logger.Debug("Book a Reading Room visit API Starting Up");
+                CreateHostBuilder(args).Build().Run();
+            }
+            catch (System.Exception e)
+            {
+                logger.Error(e, "Book a Reading Room visit API is stopping due to an exception");
+                throw;
+            }
+            finally
+            {
+                NLog.LogManager.Shutdown();
+            }
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -21,11 +31,11 @@ namespace book_a_reading_room_visit.api
                 .ConfigureLogging(logging =>
                 {
                     logging.ClearProviders();
-                    logging.AddConsole();
+                    logging.SetMinimumLevel(LogLevel.Trace);
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
-                });
+                }).UseNLog();
     }
 }

--- a/book-a-reading-room-visit.api/Program.cs
+++ b/book-a-reading-room-visit.api/Program.cs
@@ -66,9 +66,6 @@ namespace book_a_reading_room_visit.api
             // N.B. This returns null so have to find all targets and then cast!
             //SlackTarget slackTarget = configuration.FindTargetByName<SlackTarget>("slackTarget");
             SlackTarget slackTarget = (SlackTarget)targets.First(t => t.GetType() == typeof(SlackTarget));
-            
-            Target target = configuration.FindTargetByName("slackTarget");
-
             slackTarget.WebHookUrl = slackWebhookUrl;
             LogManager.Configuration = configuration;
         }

--- a/book-a-reading-room-visit.api/Properties/launchSettings.json
+++ b/book-a-reading-room-visit.api/Properties/launchSettings.json
@@ -36,7 +36,8 @@
         "KewBookingConnection": "Data Source= (localdb)\\MSSQLLocalDB; Initial Catalog=KewBooking",
         "HomeURL": "https://dev-www.nationalarchives.gov.uk/book-a-reading-room-visit",
         "AWS_PROFILE": "devdsadmin",
-        "AWS_REGION": "eu-west-2"
+        "AWS_REGION": "eu-west-2",
+        "KBS_SLACK_WEBHOOK": "https://hooks.slack.com/services/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"
       }
     }
   }

--- a/book-a-reading-room-visit.api/Service/Impl/BookingService.cs
+++ b/book-a-reading-room-visit.api/Service/Impl/BookingService.cs
@@ -647,8 +647,8 @@ namespace book_a_reading_room_visit.api.Service
                                 // This will terminate any further email processing and raise a 500 response (as at present).
                                 throw;
                             }
-                            // Wait a second before trying again.
-                            await Task.Delay(1000);
+                            // Wait before trying again.
+                            await Task.Delay(attempts * 1000);
                         }
 
                     } while (true);

--- a/book-a-reading-room-visit.api/Service/Interface/IBookingService.cs
+++ b/book-a-reading-room-visit.api/Service/Interface/IBookingService.cs
@@ -1,4 +1,5 @@
 ﻿using book_a_reading_room_visit.model;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/book-a-reading-room-visit.api/appsettings.Development.json
+++ b/book-a-reading-room-visit.api/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
   "EmailSettings": {
-    "FromAddress": "Book a visit - The National Archives <bookareadingroomvisit@nationalarchives.gov.uk>",
-    "DSDFromAddress": "Book a visit - The National Archives <noreply@nationalarchives.gov.uk>",
+    "FromAddress": "Book a visit - The National Archives <bookareadingroomvisit@pro.gov.uk>",
+    "DSDFromAddress": "Book a visit - The National Archives <noreply@pro.gov.uk>",
     "InvalidReminderSubject": "Reminder from The National Archives: Complete your document order before the deadline",
     "PostVisitSubject": "Test : Your booking for {0} : How was your visit?",
     "ReservationSubject": "Test : Reservation to visit The National Archives on {0}",

--- a/book-a-reading-room-visit.api/appsettings.Development.json
+++ b/book-a-reading-room-visit.api/appsettings.Development.json
@@ -1,0 +1,11 @@
+{
+  "EmailSettings": {
+    "FromAddress": "Book a visit - The National Archives <bookareadingroomvisit@nationalarchives.gov.uk>",
+    "DSDFromAddress": "Book a visit - The National Archives <noreply@nationalarchives.gov.uk>",
+    "InvalidReminderSubject": "Reminder from The National Archives: Complete your document order before the deadline",
+    "PostVisitSubject": "Test : Your booking for {0} : How was your visit?",
+    "ReservationSubject": "Test : Reservation to visit The National Archives on {0}",
+    "StandardOrderAddress": "AdvancedDocumentOrderTest@nationalarchives.gov.uk",
+    "ValidReminderSubject": "Test : Reminder from The National Archives: Last chance to edit your document order"
+  }
+}

--- a/book-a-reading-room-visit.api/appsettings.json
+++ b/book-a-reading-room-visit.api/appsettings.json
@@ -34,6 +34,7 @@
     "PostVisitSubject": "Your booking for {0} : How was your visit?",
     "ReservationSubject": "Reservation to visit The National Archives on {0}",
     "StandardOrderAddress": "AdvancedDocumentOrder@nationalarchives.gov.uk",
-    "ValidReminderSubject": "Reminder from The National Archives: Last chance to edit your document order"
+    "ValidReminderSubject": "Reminder from The National Archives: Last chance to edit your document order",
+    "LoopSendDelay":  "10"
   }
 }

--- a/book-a-reading-room-visit.api/book-a-reading-room-visit.api.csproj
+++ b/book-a-reading-room-visit.api/book-a-reading-room-visit.api.csproj
@@ -6,10 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="C:\Users\boreilly\.nuget\packages\nlog.config\4.7.11\contentFiles\any\any\NLog.config" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Amazon.AspNetCore.DataProtection.SSM" Version="2.1.0" />
     <PackageReference Include="AWS.Logger.AspNetCore" Version="3.2.0" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0.10" />
     <PackageReference Include="AWSSDK.SimpleEmail" Version="3.7.0.10" />
+    <PackageReference Include="NLog.Slack" Version="2.0.0" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.2" />
   </ItemGroup>
 

--- a/book-a-reading-room-visit.api/nlog.config
+++ b/book-a-reading-room-visit.api/nlog.config
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd NLog.xsd"
+      autoReload="true"
+      throwExceptions="false">
+
+  <extensions>
+    <add assembly="NLog.Slack" />
+  </extensions>
+
+  <targets async="true">
+    <target xsi:type="File" name="fileTarget" fileName="${basedir}/logs/${shortdate}.log" layout="${longdate} ${uppercase:${level}} ${message}" />
+    <target xsi:type="ColoredConsole" name="consoleTarget"  layout="${longdate} ${uppercase:${level}} ${message}" />
+    <target xsi:type="Slack"
+            name="slackTarget"
+            layout="${message}"
+            webHookUrl="https://hooks.slack.com/services/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"
+            compact="false">
+
+      <field name="Machine Name" layout="${machinename}" />
+      <field name="Process Name" layout="${processname}" />
+      <field name="Process PID" layout="${processid}" />
+    </target>
+  </targets>
+  <rules>
+    <!--<logger name="*" minlevel="Trace" writeTo="consoleTarget" />-->
+    <logger name="*" minlevel="Trace" writeTo="fileTarget" />
+    <logger name="*" minlevel="Info" writeTo="slackTarget" />
+  </rules>
+</nlog>

--- a/book-a-reading-room-visit.api/nlog.config
+++ b/book-a-reading-room-visit.api/nlog.config
@@ -15,8 +15,8 @@
     <target xsi:type="Slack"
             name="slackTarget"
             layout="${message}"
-            webHookUrl="https://hooks.slack.com/services/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"
-            compact="false">
+            webHookUrl="(from environment variable)"
+            >
 
       <field name="Machine Name" layout="${machinename}" />
       <field name="Process Name" layout="${processname}" />


### PR DESCRIPTION
For DSD emails, the code will try up to 3 times to send the email on encountering an exception, waiting 1 second between each attempt.  For all DSD emails within the SendBookingConfirmationEmailsAsync loop, a delay in milliseconds can be set via the EmailSettings-LoopSendDelay in appsettings.json