### PR TITLE
Feature/email headers kbs319

### DIFF
--- a/book-a-reading-room-visit.api/Email/AwsRawEmailSender.cs
+++ b/book-a-reading-room-visit.api/Email/AwsRawEmailSender.cs
@@ -2,6 +2,7 @@
 using Amazon.SimpleEmail.Model;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -31,27 +32,45 @@ namespace book_a_reading_room_visit.api.Email
 
         private  MemoryStream BuildMessageStream(string from, string to, string subject, string textBody, string htmlBody)
         {
-            var sb = new StringBuilder($"From: {from}\nTo: {to}\n");
-            sb.Append($"Subject: {subject}\n");
-            sb.Append($"multipart/mixed;boundary = \"a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a\"n");
+            string senderDisplayname = from.Substring(0, from.IndexOf("<") - 1);
+            string senderEmail = from.Substring(from.IndexOf("<"));
+
+            var sb = new StringBuilder($"From: \"{senderDisplayname}\" {senderEmail}");
             sb.Append("\n");
-            sb.Append("--a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a");
+            sb.Append($"To: {to}");
+            sb.Append("\n");
+            sb.Append($"Subject: {subject}");
+            sb.Append("\n");
             sb.Append("X-SES-CONFIGURATION-SET: KBSEmailsToDSD");
-            sb.Append("X-SES-MESSAGE-TAGS: booking - confirmation = adv - order");
-            sb.Append("Content-Type: multipart/alternative;boundary = \"sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a\"");
-            sb.Append("--sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a");
-            sb.Append("Content - Type: text / plain; charset = iso - 8859 - 1");
-            sb.Append("Content - Transfer - Encoding: quoted - printable");
-
+            sb.Append("\n");
+            sb.Append("X-SES-MESSAGE-TAGS: booking-confirmation=adv-order");
+            sb.Append("\n");
+            sb.Append("Content-Type: multipart/alternative;boundary=\"Multipart_687cbcb1065148178784dc4ea27d7cd6\"");
+            sb.Append("\n\n");
+            sb.Append("--Multipart_687cbcb1065148178784dc4ea27d7cd6");
+            sb.Append("\n");
+            sb.Append("Content-Type: text/plain; charset=iso-8859-1");
+            sb.Append("\n");
+            sb.Append("Content-Transfer-Encoding: quoted-printable");
+            
+            sb.Append("\n\n");
             sb.Append(textBody);
+            sb.Append("\n\n");
 
-            sb.Append("--sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1asb.");
-            sb.Append("Content - Type: text / html; charset = iso - 8859 - 1");
-            sb.Append("Content - Transfer - Encoding: quoted - printable");
-
+            sb.Append("--Multipart_687cbcb1065148178784dc4ea27d7cd6");
+            sb.Append("\n");
+            //sb.Append("Content-Type: text/html; charset=iso-8859-1");
+            sb.Append("Content-Type: text/html; charset=UTF-8");
+            sb.Append("\n");
+            sb.Append("Content-Transfer-Encoding: quoted-printable");
+            
+            sb.Append("\n\n");
             sb.Append(htmlBody);
+            sb.Append("\n\n");
 
-            sb.Append("-sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a--");
+            sb.Append("--Multipart_687cbcb1065148178784dc4ea27d7cd6--");
+
+            Debug.Print(sb.ToString());
 
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(sb.ToString()));
 

--- a/book-a-reading-room-visit.api/Email/AwsRawEmailSender.cs
+++ b/book-a-reading-room-visit.api/Email/AwsRawEmailSender.cs
@@ -1,0 +1,61 @@
+﻿using Amazon.SimpleEmail;
+using Amazon.SimpleEmail.Model;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace book_a_reading_room_visit.api.Email
+{
+    public class AwsRawEmailSender : IEmailSender
+    {
+
+        private readonly IAmazonSimpleEmailService _amazonSimpleEmailService;
+
+        public AwsRawEmailSender(IAmazonSimpleEmailService amazonSimpleEmailService)
+        {
+            _amazonSimpleEmailService = amazonSimpleEmailService;
+        }
+
+        public async Task SendEmail(string from, string to, string subject, string textBody, string htmlBody)
+        {
+            MemoryStream messageStream = BuildMessageStream(from, to, subject, textBody, htmlBody);
+
+            var rawMessage = new RawMessage(messageStream);
+            var rawEmailRequest = new SendRawEmailRequest(rawMessage);
+
+            await _amazonSimpleEmailService.SendRawEmailAsync(rawEmailRequest);
+        }
+
+        private  MemoryStream BuildMessageStream(string from, string to, string subject, string textBody, string htmlBody)
+        {
+            var sb = new StringBuilder($"From: {from}\nTo: {to}\n");
+            sb.Append($"Subject: {subject}\n");
+            sb.Append($"multipart/mixed;boundary = \"a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a\"n");
+            sb.Append("\n");
+            sb.Append("--a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a");
+            sb.Append("X-SES-CONFIGURATION-SET: KBSEmailsToDSD");
+            sb.Append("X-SES-MESSAGE-TAGS: booking - confirmation = adv - order");
+            sb.Append("Content-Type: multipart/alternative;boundary = \"sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a\"");
+            sb.Append("--sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a");
+            sb.Append("Content - Type: text / plain; charset = iso - 8859 - 1");
+            sb.Append("Content - Transfer - Encoding: quoted - printable");
+
+            sb.Append(textBody);
+
+            sb.Append("--sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1asb.");
+            sb.Append("Content - Type: text / html; charset = iso - 8859 - 1");
+            sb.Append("Content - Transfer - Encoding: quoted - printable");
+
+            sb.Append(htmlBody);
+
+            sb.Append("-sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a--");
+
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(sb.ToString()));
+
+            return stream;
+        }
+    }
+}

--- a/book-a-reading-room-visit.api/Email/IEmailSender.cs
+++ b/book-a-reading-room-visit.api/Email/IEmailSender.cs
@@ -1,0 +1,12 @@
+﻿using book_a_reading_room_visit.model;
+using System.Threading.Tasks;
+
+namespace book_a_reading_room_visit.api.Email
+{
+    public interface IEmailSender
+    {
+        Task SendEmail(string from, string to, string subject, string textBody, string htmlBody);
+    }
+}
+
+        

--- a/book-a-reading-room-visit.api/Helper/EmailHelper.cs
+++ b/book-a-reading-room-visit.api/Helper/EmailHelper.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace book_a_reading_room_visit.api.Helper
+{
+    public static class EmailHelper
+    {
+        public static MemoryStream MessageStream(string from, string to, string subject, string textBody, string htmlBody)
+        {
+            var sb = new StringBuilder($"From: {from}\nTo: {to}\n");
+            sb.Append($"Subject: {subject}\n");
+            sb.Append($"multipart/mixed;boundary = \"a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a\"n");
+            sb.Append("\n");
+            sb.Append("--a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a");
+            sb.Append("X-SES-CONFIGURATION-SET: KBSEmailsToDSD");
+            sb.Append("X-SES-MESSAGE-TAGS: booking - confirmation = adv - order");
+            sb.Append("Content-Type: multipart/alternative;boundary = \"sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a\"");
+            sb.Append("--sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a");
+            sb.Append("Content - Type: text / plain; charset = iso - 8859 - 1");
+            sb.Append("Content - Transfer - Encoding: quoted - printable");
+
+            sb.Append(textBody);
+
+            sb.Append("--sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1asb.");
+            sb.Append("Content - Type: text / html; charset = iso - 8859 - 1");
+            sb.Append("Content - Transfer - Encoding: quoted - printable");
+
+            sb.Append(htmlBody);
+
+            sb.Append("-sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a--");
+
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(sb.ToString()));
+
+            return stream;
+        }
+    }
+}

--- a/book-a-reading-room-visit.api/Service/Impl/EmailService.cs
+++ b/book-a-reading-room-visit.api/Service/Impl/EmailService.cs
@@ -1,5 +1,6 @@
 ﻿using Amazon.SimpleEmail;
 using Amazon.SimpleEmail.Model;
+using book_a_reading_room_visit.api.Helper;
 using book_a_reading_room_visit.model;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
@@ -86,33 +87,41 @@ namespace book_a_reading_room_visit.api.Service
             var xDocument = emailType == EmailType.DSDBookingConfirmation ? GetDSDXDocument(bookingModel) :  GetXDocument(bookingModel);
             var htmlBody = GetHtmlBody(emailType, xDocument);
             var textBody = GetTextBody(emailType, bookingModel);
-            var sendRequest = new SendEmailRequest
-            {
-                Source = fromAddress,
-                Destination = new Destination
-                {
-                    ToAddresses = toAddress.Split(',').ToList()
-                },
-                Message = new Message
-                {
-                    Subject = new Content(subject),
-                    Body = new Body
-                    {
-                        Html = new Content
-                        {
-                            Charset = "UTF-8",
-                            Data = htmlBody
-                        },
-                        Text = new Content
-                        {
-                            Charset = "UTF-8",
-                            Data = textBody
-                        }
-                    }
+            //var sendRequest = new SendEmailRequest
+            //{
+            //    Source = fromAddress,
+            //    Destination = new Destination
+            //    {
+            //        ToAddresses = toAddress.Split(',').ToList()
+            //    },
+            //    Message = new Message
+            //    {
+            //        Subject = new Content(subject),
+            //        Body = new Body
+            //        {
+            //            Html = new Content
+            //            {
+            //                Charset = "UTF-8",
+            //                Data = htmlBody
+            //            },
+            //            Text = new Content
+            //            {
+            //                Charset = "UTF-8",
+            //                Data = textBody
+            //            }
+            //        }
+            //    }
+            //};
 
-                }
-            };
-            await _amazonSimpleEmailService.SendEmailAsync(sendRequest);
+
+
+
+            var rawMessage = new RawMessage(EmailHelper.MessageStream(from: fromAddress, to: toAddress, subject: subject, textBody: textBody, htmlBody: htmlBody));
+            var rawEmailRequest = new SendRawEmailRequest(rawMessage);
+
+            await _amazonSimpleEmailService.SendRawEmailAsync(rawEmailRequest);
+
+            //await _amazonSimpleEmailService.SendEmailAsync(sendRequest);
         }
 
         internal string GetTextBody(EmailType emailType, BookingModel bookingModel)

--- a/book-a-reading-room-visit.api/Service/Impl/EmailService.cs
+++ b/book-a-reading-room-visit.api/Service/Impl/EmailService.cs
@@ -1,5 +1,6 @@
 ﻿using Amazon.SimpleEmail;
 using Amazon.SimpleEmail.Model;
+using book_a_reading_room_visit.api.Email;
 using book_a_reading_room_visit.api.Helper;
 using book_a_reading_room_visit.model;
 using Microsoft.Extensions.Configuration;
@@ -22,13 +23,13 @@ namespace book_a_reading_room_visit.api.Service
 {
     public class EmailService : IEmailService
     {
-        private readonly IAmazonSimpleEmailService _amazonSimpleEmailService;
         private readonly IConfiguration _configuration;
+        private readonly IEmailSender _emailSender;
 
-        public EmailService(IAmazonSimpleEmailService amazonSimpleEmailService, IConfiguration configuration)
+        public EmailService(IEmailSender emailSender, IConfiguration configuration)
         {
-            _amazonSimpleEmailService = amazonSimpleEmailService;
             _configuration = configuration;
+            _emailSender = emailSender;
         }
         public async Task SendEmailAsync(EmailType emailType, string toAddress, BookingModel bookingModel)
         {
@@ -87,41 +88,9 @@ namespace book_a_reading_room_visit.api.Service
             var xDocument = emailType == EmailType.DSDBookingConfirmation ? GetDSDXDocument(bookingModel) :  GetXDocument(bookingModel);
             var htmlBody = GetHtmlBody(emailType, xDocument);
             var textBody = GetTextBody(emailType, bookingModel);
-            //var sendRequest = new SendEmailRequest
-            //{
-            //    Source = fromAddress,
-            //    Destination = new Destination
-            //    {
-            //        ToAddresses = toAddress.Split(',').ToList()
-            //    },
-            //    Message = new Message
-            //    {
-            //        Subject = new Content(subject),
-            //        Body = new Body
-            //        {
-            //            Html = new Content
-            //            {
-            //                Charset = "UTF-8",
-            //                Data = htmlBody
-            //            },
-            //            Text = new Content
-            //            {
-            //                Charset = "UTF-8",
-            //                Data = textBody
-            //            }
-            //        }
-            //    }
-            //};
 
+            await _emailSender.SendEmail(from: fromAddress, to: toAddress, subject: subject, textBody: textBody, htmlBody: htmlBody);
 
-
-
-            var rawMessage = new RawMessage(EmailHelper.MessageStream(from: fromAddress, to: toAddress, subject: subject, textBody: textBody, htmlBody: htmlBody));
-            var rawEmailRequest = new SendRawEmailRequest(rawMessage);
-
-            await _amazonSimpleEmailService.SendRawEmailAsync(rawEmailRequest);
-
-            //await _amazonSimpleEmailService.SendEmailAsync(sendRequest);
         }
 
         internal string GetTextBody(EmailType emailType, BookingModel bookingModel)

--- a/book-a-reading-room-visit.api/Startup.cs
+++ b/book-a-reading-room-visit.api/Startup.cs
@@ -1,4 +1,5 @@
 using Amazon.SimpleEmail;
+using book_a_reading_room_visit.api.Email;
 using book_a_reading_room_visit.api.Service;
 using book_a_reading_room_visit.data;
 using Microsoft.AspNetCore.Builder;
@@ -31,6 +32,7 @@ namespace book_a_reading_room_visit.api
             services.AddDataProtection().PersistKeysToAWSSystemsManager("/KBS-API/DataProtection");
             services.AddAWSService<IAmazonSimpleEmailService>();
             services.AddScoped<IEmailService, EmailService>();
+            services.AddScoped<IEmailSender, AwsRawEmailSender>();
 
             services.AddLogging(config =>
             {

--- a/book-a-reading-room-visit.api/appsettings.Development.json
+++ b/book-a-reading-room-visit.api/appsettings.Development.json
@@ -1,0 +1,11 @@
+{
+  "EmailSettings": {
+    "FromAddress": "Book a visit - The National Archives <bookareadingroomvisit@nationalarchives.gov.uk>",
+    "DSDFromAddress": "Book a visit - The National Archives <noreply@nationalarchives.gov.uk>",
+    "InvalidReminderSubject": "Reminder from The National Archives: Complete your document order before the deadline",
+    "PostVisitSubject": "Test : Your booking for {0} : How was your visit?",
+    "ReservationSubject": "Test : Reservation to visit The National Archives on {0}",
+    "StandardOrderAddress": "systems.development@nationalarchives.gov.uk",
+    "ValidReminderSubject": "Test : Reminder from The National Archives: Last chance to edit your document order"
+  }
+}


### PR DESCRIPTION
Now use raw email to send via AWS API.  This allows us to add additional headers for use with CloudTrail. i.e.
            X-SES-CONFIGURATION-SET: KBSEmailsToDSD
            X-SES-MESSAGE-TAGS: booking-confirmation=adv-order