### PR TITLE
Add placeholder copy and maxlength attribute to Additional Requirements

### DIFF
--- a/book-a-reading-room-visit.web/Views/DocumentOrder/OrderDocuments.cshtml
+++ b/book-a-reading-room-visit.web/Views/DocumentOrder/OrderDocuments.cshtml
@@ -160,7 +160,7 @@
                         }
                         else
                         {
-                            @Html.TextAreaFor(Model => Model.AdditionalRequirements, new { id = "additional-reqs" })
+                            @Html.TextAreaFor(Model => Model.AdditionalRequirements, new { id = "additional-reqs", @maxlength = "2000" })
                         }
                     </fieldset>
                     <button class="button" type="submit">Save and review</button>

--- a/book-a-reading-room-visit.web/Views/DocumentOrder/OrderDocuments.cshtml
+++ b/book-a-reading-room-visit.web/Views/DocumentOrder/OrderDocuments.cshtml
@@ -142,7 +142,7 @@
 
                     <fieldset>
                         <legend>
-                            <label for="additional-reqs">Access needs and research requests</label>
+                            <label for="additional-reqs">Access needs and research requests (maximum 2,000 characters)</label>
                         </legend>
 
                         <p class="helper-text">
@@ -155,7 +155,7 @@
 
                         @if (ViewData.ModelState["AdditionalRequirements"]?.Errors.Count() > 0)
                         {
-                            @Html.TextAreaFor(Model => Model.AdditionalRequirements, new { id = "additional-reqs", @class = "form-warning", aria_describedby = "validation-message-additional-requirements" })
+                            @Html.TextAreaFor(Model => Model.AdditionalRequirements, new { id = "additional-reqs", @class = "form-warning", aria_describedby = "validation-message-additional-requirements", @maxlength = "2000" })
                             @Html.ValidationMessageFor(Model => Model.AdditionalRequirements, "", new { @class = "form-error", id = "validation-message-additional-requirements" })
                         }
                         else


### PR DESCRIPTION
This PR introduces the `maxlength` attribute and some placeholder copy to the associated `<label>` element. The label now reads: 

> Access needs and research requests (maximum 2,000 characters)

The [Jira ticket](https://national-archives.atlassian.net/browse/ACCESS-34?atlOrigin=eyJpIjoiNDQ4MTdlMGYxMTEyNGMyMzhmMGM4YjI3OTUyZGNiYjMiLCJwIjoiaiJ9) includes screenshots of the current interface and I'll pop a message in the Jira ticket to ask if @MGDeVille is happy with the proposed content.  