### PR TITLE
Added separate validation regex for series validation, which doesn't …

### DIFF
--- a/book-a-reading-room-visit.test/ReferenceUnitTest.cs
+++ b/book-a-reading-room-visit.test/ReferenceUnitTest.cs
@@ -98,6 +98,7 @@ namespace book_a_reading_room_visit.test
         };
 
         private readonly CheckReference _checkReferenceAttribute = new CheckReference();
+        private readonly CheckSeries _checkSeriesAttribute = new CheckSeries();
 
         [TestMethod]
         public Task References_Validate_As_Expected()
@@ -107,6 +108,38 @@ namespace book_a_reading_room_visit.test
                 Assert.AreEqual(_expectedResults[reference], _checkReferenceAttribute.IsValid(reference));
             }
 
+            return Task.CompletedTask;
+        }
+
+        [TestMethod]
+        public Task Series_Ref_Single_Space_IsValid()
+        {
+            string series = "FO 371";
+            Assert.IsTrue(_checkSeriesAttribute.IsValid(series));
+            return Task.CompletedTask;
+        }
+
+        [TestMethod]
+        public Task Series_Ref_No_Space_NotValid()
+        {
+            string series = "FO371";
+            Assert.IsFalse(_checkSeriesAttribute.IsValid(series));
+            return Task.CompletedTask;
+        }
+
+        [TestMethod]
+        public Task Series_Ref_Multi_Space_NotValid()
+        {
+            string series = "FO  371";
+            Assert.IsFalse(_checkSeriesAttribute.IsValid(series));
+            return Task.CompletedTask;
+        }
+
+        [TestMethod]
+        public Task Series_Ref_With_Piece_NotValid()
+        {
+            string series = "FO 371/1";
+            Assert.IsFalse(_checkSeriesAttribute.IsValid(series));
             return Task.CompletedTask;
         }
     }

--- a/book-a-reading-room-visit.web/Helper/Constants.cs
+++ b/book-a-reading-room-visit.web/Helper/Constants.cs
@@ -26,5 +26,6 @@
         public const string TNADomain = "nationalarchives.gov.uk";
 
         public const string Invalid_Document_Reference = "The document reference you have entered has an invalid format.  References must start with 1-4 letters, followed by a space, then 1-4 digits";
+        public const string Invalid_Series_Reference = "The series reference you have entered has an invalid format.  Series references must start with 1-4 letters, followed by a space, then 1-4 digits";
     }
 }

--- a/book-a-reading-room-visit.web/Models/DocumentOrderViewModel.cs
+++ b/book-a-reading-room-visit.web/Models/DocumentOrderViewModel.cs
@@ -16,7 +16,7 @@ namespace book_a_reading_room_visit.web.Models
         public SeatTypes SeatType { get; set; }
         public string SeatNumber { get; set; }
         [MaxLength(50)]
-        [CheckReference(ErrorMessage = Constants.Invalid_Document_Reference)]
+        [CheckSeries(ErrorMessage = Constants.Invalid_Series_Reference)]
         [CheckForHtmlTags(ErrorMessage = Constants.Html_Tags_Not_Allowed)]
         public string Series { get; set; }
         [CustomHtmlValidation(ErrorMessage = Constants.Html_Tags_Not_Allowed)]

--- a/book-a-reading-room-visit.web/Validators/CheckReference.cs
+++ b/book-a-reading-room-visit.web/Validators/CheckReference.cs
@@ -16,10 +16,10 @@ namespace book_a_reading_room_visit.web.Validators
 
         public override bool IsValid(object value)
         {
-            string input = value as string;
+            string input = (value as string)?.Trim();
             if (string.IsNullOrWhiteSpace(input))
             {
-                return base.IsValid(value);
+                return base.IsValid(input);
             }
 
 
@@ -31,7 +31,7 @@ namespace book_a_reading_room_visit.web.Validators
             }
             else
             {
-                return base.IsValid(value);
+                return base.IsValid(input);
             }
         }
     }

--- a/book-a-reading-room-visit.web/Validators/CheckSeries.cs
+++ b/book-a-reading-room-visit.web/Validators/CheckSeries.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace book_a_reading_room_visit.web.Validators
+{
+    public class CheckSeries : RegularExpressionAttribute
+    {
+        // Users must include a space in the series reference.  Since the bulk order
+        // service doens;t recognise series references without a space, although it's
+        // OK with unspaced piece and item refereneces.
+        private static readonly string mainRegex = @"^[A-Z]{1,4} {1}[0-9]{1,4}$";
+
+        public CheckSeries() : base(mainRegex)
+        {
+
+        }
+
+        public override bool IsValid(object value)
+        {
+            string input = (value as string)?.Trim();
+            return base.IsValid(input);
+        }
+    }
+}


### PR DESCRIPTION
…permit spaces (unlike piece and item references).  Also we now trim all references entered by users before validating against the regexes.